### PR TITLE
too many arguments

### DIFF
--- a/pkg/adaptor/elasticsearch.go
+++ b/pkg/adaptor/elasticsearch.go
@@ -117,10 +117,10 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 	}
 	switch msg.Op {
 	case message.Delete:
-		e.indexer.Delete(e.index, _type, id, false)
+		e.indexer.Delete(e.index, _type, id)
 		err = nil
 	default:
-		err = e.indexer.Index(e.index, _type, id, "", "", nil, msg.Data, false)
+		err = e.indexer.Index(e.index, _type, id, "", "", nil, msg.Data)
 	}
 	if err != nil {
 		e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)


### PR DESCRIPTION
When I tried to:

``` go
go get -a ./cmd/...
```

I was getting these errors:

```
pkg/adaptor/elasticsearch.go:120: too many arguments in call to e.indexer.Delete
pkg/adaptor/elasticsearch.go:123: too many arguments in call to e.indexer.Index
```
